### PR TITLE
Align the longer translated "No data" text properly

### DIFF
--- a/qml/components/thirdparty/GraphData.qml
+++ b/qml/components/thirdparty/GraphData.qml
@@ -288,6 +288,7 @@ Item {
                 id: textNoData
                 anchors.centerIn: parent
                 color: lineColor
+                horizontalAlignment: Text.AlignHCenter
                 text: qsTr("No data - Click to fetch data");
                 visible: noData
             }


### PR DESCRIPTION
While testing my translation on a small screen of Jolla 1 I noticed that the Russian string for "No data - Click to fetch data" is longer and does not fit the width of the graph area. I had to make it 2 lines, but it looks much nicer if the text is centered. There is no visible change in the English UI.