### PR TITLE
Russian translation updated

### DIFF
--- a/translations/harbour-watchlist-ru.ts
+++ b/translations/harbour-watchlist-ru.ts
@@ -1,55 +1,84 @@
-<!DOCTYPE TS><TS>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0">
 <context>
     <name>AboutPage</name>
     <message>
         <source>Reset Database</source>
+        <extracomment>AboutPage pully - reset database</extracomment>
         <translation>Сброс базы данных</translation>
     </message>
     <message>
         <source>About Watchlist</source>
+        <extracomment>AboutPage title - header
+----------
+AboutPage title - about text title</extracomment>
         <translation>О программе</translation>
     </message>
     <message>
         <source>This is app is a simple stock watchlist for Sailfish OS. Watchlist is open source and licensed under the GPL v3.</source>
+        <extracomment>AboutPage text - about text</extracomment>
         <translation>Простой инструмент слежения за курсами ценных бумаг для Sailfish OS. Исходный код Watchlist открыт и доступен под GPL v3.</translation>
     </message>
     <message>
         <source>Version</source>
+        <extracomment>AboutPage version label</extracomment>
         <translation>Версия</translation>
     </message>
     <message>
         <source>Author</source>
+        <extracomment>AboutPage author label</extracomment>
         <translation>Автор</translation>
     </message>
     <message>
         <source>Translators</source>
+        <extracomment>AboutPage translators label</extracomment>
         <translation>Переводчики</translation>
     </message>
     <message>
         <source>Contributors</source>
+        <extracomment>AboutPage contributors label</extracomment>
         <translation>Вклад внесли</translation>
     </message>
     <message>
         <source>Source code</source>
+        <extracomment>AboutPage about source label</extracomment>
         <translation>Исходный код</translation>
+    </message>
+    <message>
+        <source>Viacheslav Dikonov (ru)</source>
+        <translation>Вячеслав Диконов (ru)</translation>
+    </message>
+    <message>
+        <source>Debug Infos</source>
+        <extracomment>AboutPage translators label</extracomment>
+        <translation>Данные для отладки</translation>
+    </message>
+    <message>
+        <source>Screen size : </source>
+        <translation>Размер экрана : </translation>
     </message>
 </context>
 <context>
     <name>AddStockPage</name>
     <message>
         <source>Search Results</source>
+        <extracomment>AddStockPage search result header</extracomment>
         <translation>Результаты поиска</translation>
     </message>
     <message>
         <source>Find your Stock...</source>
+        <extracomment>AddStockPage search result input field</extracomment>
         <translation>Поиск бумаг...</translation>
     </message>
     <message>
         <source>No results found</source>
+        <extracomment>AddStockPage no results label</extracomment>
         <translation>Ничего не найдено</translation>
     </message>
     <message>
         <source>Add</source>
+        <extracomment>AddStockPage add menu item</extracomment>
         <translation>Добавить</translation>
     </message>
 </context>
@@ -57,14 +86,19 @@
     <name>AlarmNotification</name>
     <message>
         <source>%1</source>
+        <extracomment>AlarmNotification placeholder for stock name
+----------
+AlarmNotification placeholder for stock name</extracomment>
         <translation>%1</translation>
     </message>
     <message>
         <source>The share has just dropped below %1.</source>
+        <extracomment>AlarmNotification stock dropped below</extracomment>
         <translation>Курс упал ниже %1.</translation>
     </message>
     <message>
         <source>The share has just risen above %1.</source>
+        <extracomment>AlarmNotification stock has risen above</extracomment>
         <translation>Курс вырос выше %1.</translation>
     </message>
 </context>
@@ -102,42 +136,52 @@
     <name>SettingsPage</name>
     <message>
         <source>Settings</source>
+        <extracomment>SettingsPage settings title</extracomment>
         <translation>Настройка</translation>
     </message>
     <message>
         <source>Download chart data</source>
+        <extracomment>SettingsPage download chart data</extracomment>
         <translation>Загрузка графиков</translation>
     </message>
     <message>
         <source>Defines strategy to download the chart data</source>
+        <extracomment>SettingsPage download strategy explanation</extracomment>
         <translation>Стратегия обновления графиков курса</translation>
     </message>
     <message>
         <source>Always</source>
+        <extracomment>SettingsPage download strategy always</extracomment>
         <translation>Всегда</translation>
     </message>
     <message>
         <source>Only on WiFi</source>
+        <extracomment>SettingsPage download strategy only on wifi</extracomment>
         <translation>Только по WiFi</translation>
     </message>
     <message>
         <source>Only manually</source>
+        <extracomment>SettingsPage download strategy only manually</extracomment>
         <translation>Только вручную</translation>
     </message>
     <message>
         <source>Sorting order</source>
+        <extracomment>SettingsPage sorting order watchlist page</extracomment>
         <translation>Порядок сортировки</translation>
     </message>
     <message>
         <source>Defines sorting order of watchlist entries</source>
+        <extracomment>SettingsPage sorting order description</extracomment>
         <translation>Определяет порядок списка бумаг в Watchlist</translation>
     </message>
     <message>
         <source>By change</source>
+        <extracomment>SettingsPage sorting order by change</extracomment>
         <translation>По изменениям</translation>
     </message>
     <message>
         <source>By name</source>
+        <extracomment>SettingsPage sorting order by name</extracomment>
         <translation>По имени</translation>
     </message>
 </context>
@@ -173,41 +217,78 @@
     </message>
 </context>
 <context>
+    <name>StockChartsView</name>
+    <message>
+        <source>Charts</source>
+        <extracomment>StockChartsView chart section header</extracomment>
+        <translation>Графики</translation>
+    </message>
+    <message>
+        <source>Intraday</source>
+        <translation>1 день</translation>
+    </message>
+    <message>
+        <source>30 days</source>
+        <translation>30 дней</translation>
+    </message>
+    <message>
+        <source>3 months</source>
+        <translation>3 месяца</translation>
+    </message>
+    <message>
+        <source>1 Year</source>
+        <translation>1 год</translation>
+    </message>
+    <message>
+        <source>3 Years</source>
+        <translation>3 года</translation>
+    </message>
+</context>
+<context>
     <name>StockDetailsPage</name>
     <message>
         <source>Currency</source>
+        <extracomment>StockDetailsPage page currency</extracomment>
         <translation>Валюта</translation>
     </message>
     <message>
         <source>General data</source>
+        <extracomment>StockDetailsPage page general data</extracomment>
         <translation>Общая информация</translation>
     </message>
     <message>
         <source>Isin</source>
+        <extracomment>StockDetailsPage page isin</extracomment>
         <translation>ISIN код</translation>
     </message>
     <message>
         <source>Symbol</source>
+        <extracomment>StockDetailsPage page symbol</extracomment>
         <translation>Символ</translation>
     </message>
     <message>
         <source>Stock Market</source>
+        <extracomment>StockDetailsPage page stock market</extracomment>
         <translation>Биржа</translation>
     </message>
     <message>
         <source>Trading data</source>
+        <extracomment>StockDetailsPage page trading data</extracomment>
         <translation>Курс</translation>
     </message>
     <message>
         <source>Price</source>
+        <extracomment>StockDetailsPage page price</extracomment>
         <translation>Цена</translation>
     </message>
     <message>
         <source>Timestamp</source>
+        <extracomment>StockDetailsPage page timestamp</extracomment>
         <translation>Время</translation>
     </message>
     <message>
         <source>Charts</source>
+        <extracomment>StockDetailsPage page intraday chart</extracomment>
         <translation>График</translation>
     </message>
     <message>
@@ -224,61 +305,179 @@
     </message>
     <message>
         <source>Change abs.</source>
+        <extracomment>StockDetailsPage page change absolute</extracomment>
         <translation>Движение абс.</translation>
     </message>
     <message>
         <source>Change rel.</source>
+        <extracomment>StockDetailsPage page change relative</extracomment>
         <translation>Движение отн.</translation>
     </message>
     <message>
         <source>Ask</source>
+        <extracomment>StockDetailsPage page ask</extracomment>
         <translation>Предложение</translation>
     </message>
     <message>
         <source>Bid</source>
+        <extracomment>StockDetailsPage page bid</extracomment>
         <translation>Покупка</translation>
     </message>
     <message>
         <source>High</source>
+        <extracomment>StockDetailsPage page high</extracomment>
         <translation>Максимум</translation>
     </message>
     <message>
         <source>Low</source>
+        <extracomment>StockDetailsPage page low</extracomment>
         <translation>Минимум</translation>
     </message>
     <message>
         <source>Volume</source>
+        <extracomment>StockDetailsPage page volume</extracomment>
         <translation>Объём</translation>
+    </message>
+</context>
+<context>
+    <name>StockDetailsView</name>
+    <message>
+        <source>General data</source>
+        <extracomment>StockDetailsPage page general data</extracomment>
+        <translation>Общая информация</translation>
+    </message>
+    <message>
+        <source>Currency</source>
+        <extracomment>StockDetailsPage page currency</extracomment>
+        <translation>Валюта</translation>
+    </message>
+    <message>
+        <source>Isin</source>
+        <extracomment>StockDetailsPage page isin</extracomment>
+        <translation>ISIN код</translation>
+    </message>
+    <message>
+        <source>Symbol</source>
+        <extracomment>StockDetailsPage page symbol</extracomment>
+        <translation>Символ</translation>
+    </message>
+    <message>
+        <source>Stock Market</source>
+        <extracomment>StockDetailsPage page stock market</extracomment>
+        <translation>Биржа</translation>
+    </message>
+    <message>
+        <source>Trading data</source>
+        <extracomment>StockDetailsPage page trading data</extracomment>
+        <translation>Курс</translation>
+    </message>
+    <message>
+        <source>Price</source>
+        <extracomment>StockDetailsPage page price</extracomment>
+        <translation>Цена</translation>
+    </message>
+    <message>
+        <source>Change abs.</source>
+        <extracomment>StockDetailsPage page change absolute</extracomment>
+        <translation>Движение абс.</translation>
+    </message>
+    <message>
+        <source>Change rel.</source>
+        <extracomment>StockDetailsPage page change relative</extracomment>
+        <translation>Движение отн.</translation>
+    </message>
+    <message>
+        <source>Timestamp</source>
+        <extracomment>StockDetailsPage page timestamp</extracomment>
+        <translation>Время</translation>
+    </message>
+    <message>
+        <source>Ask</source>
+        <extracomment>StockDetailsPage page ask</extracomment>
+        <translation>Предложение</translation>
+    </message>
+    <message>
+        <source>Bid</source>
+        <extracomment>StockDetailsPage page bid</extracomment>
+        <translation>Покупка</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <extracomment>StockDetailsPage page high</extracomment>
+        <translation>Максимум</translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <extracomment>StockDetailsPage page low</extracomment>
+        <translation>Минимум</translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <extracomment>StockDetailsPage page volume</extracomment>
+        <translation>Объём</translation>
+    </message>
+</context>
+<context>
+    <name>StockNewsView</name>
+    <message>
+        <source>This is not yet implemented - if you know a good source for stock news (json format!) - please drop me a line</source>
+        <translation>Эта функция находится в разработке.&lt;br&gt;Если вы знаете хороший источник биржевых новостей (в формате json), напишите мне.</translation>
+    </message>
+</context>
+<context>
+    <name>StockOverviewPage</name>
+    <message>
+        <source>About Watchlist</source>
+        <translation>О программе</translation>
+    </message>
+    <message>
+        <source>Details</source>
+        <translation>Подробности</translation>
+    </message>
+    <message>
+        <source>Charts</source>
+        <translation>Графики</translation>
+    </message>
+    <message>
+        <source>News</source>
+        <translation>Новости</translation>
     </message>
 </context>
 <context>
     <name>WatchlistPage</name>
     <message>
         <source>About</source>
+        <extracomment>WatchlistPage about menu item</extracomment>
         <translation>О программе</translation>
     </message>
     <message>
         <source>Settings</source>
+        <extracomment>WatchlistPage settings menu item</extracomment>
         <translation>Настройка</translation>
     </message>
     <message>
         <source>Add stock</source>
+        <extracomment>WatchlistPage add stock menu item</extracomment>
         <translation>Добавить бумагу</translation>
     </message>
     <message>
         <source>Refresh all quotes</source>
+        <extracomment>WatchlistPage refresh all quotes menu item</extracomment>
         <translation>Обновить все курсы</translation>
     </message>
     <message>
         <source>Stock quotes</source>
+        <extracomment>WatchlistPage page header</extracomment>
         <translation>Курсы</translation>
     </message>
     <message>
         <source>Configure alarm</source>
+        <extracomment>WatchlistPage configure alarm menu item</extracomment>
         <translation>Задать оповещение</translation>
     </message>
     <message>
         <source>Remove</source>
+        <extracomment>WatchlistPage remove menu item</extracomment>
         <translation>Удалить</translation>
     </message>
 </context>


### PR DESCRIPTION
Ouch!!! Redesigned UI broke all translations. Doing it at the same time with merging a new translation and releasing immediately renders the translators' work useless. The users will be unable to see the result in their language. 

It is a good style to ensure that the ts files match the source qmls and make new minor releases when translations update without waiting until they get broken by subsequent changes.

* There is a small patch adding the qsTr() function to the missing news message and my name.