### PR TITLE
Refine cover look

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -213,67 +213,59 @@ CoverBackground {
                     // height: stockQuoteRow.height + stockQuoteSeparator.height
                     height: stockQuoteColumn.height + Theme.paddingSmall
 
-                    Row {
-                        id: stockQuoteRow
-                        width: parent.width
-                        //                        spacing: Theme.paddingSmall
+                    // TODO custom - hier noch pruefen, was an margins noch machbar, sinnvoll ist
+                    Column {
+                        id: stockQuoteColumn
+                        width: parent.width // - (2 * Theme.horizontalPageMargin)
+                        // x: Theme.horizontalPageMargin
+                        height: firstRow.height //+ changeRow.height
+                        /* + secondRow.height*/ + thirdRow.height
                         anchors.verticalCenter: parent.verticalCenter
-                        anchors.horizontalCenter: parent.horizontalCenter
 
-                        // TODO custom - hier noch pruefen, was an margins noch machbar, sinnvoll ist
-                        Column {
-                            id: stockQuoteColumn
-                            width: parent.width // - (2 * Theme.horizontalPageMargin)
-                            // x: Theme.horizontalPageMargin
-                            height: firstRow.height //+ changeRow.height
-                            /* + secondRow.height*/ + thirdRow.height
-                            anchors.verticalCenter: parent.verticalCenter
+                        Row {
+                            id: firstRow
+                            width: parent.width
+                            height: Theme.fontSizeExtraSmall + Theme.paddingSmall
 
-                            Row {
-                                id: firstRow
-                                width: parent.width
-                                height: Theme.fontSizeExtraSmall + Theme.paddingSmall
+                            Label {
+                                id: stockQuoteName
+                                width: parent.width // * 8 / 10
+                                height: parent.height
+                                text: name
+                                // truncationMode: TruncationMode.Elide // TODO check for very long texts
+                                color: Theme.primaryColor
+                                font.pixelSize: Theme.fontSizeExtraSmall
+                                font.bold: true
+                                horizontalAlignment: Text.AlignLeft
+                                truncationMode: TruncationMode.Fade
+                            }
+                        }
 
-                                Label {
-                                    id: stockQuoteName
-                                    width: parent.width // * 8 / 10
-                                    height: parent.height
-                                    text: name
-                                    // truncationMode: TruncationMode.Elide // TODO check for very long texts
-                                    color: Theme.primaryColor
-                                    font.pixelSize: Theme.fontSizeExtraSmall
-                                    font.bold: true
-                                    horizontalAlignment: Text.AlignLeft
-                                    truncationMode: TruncationMode.Fade
-                                }
+                        Row {
+                            id: thirdRow
+                            width: parent.width
+                            height: Theme.fontSizeTiny + Theme.paddingSmall
+
+                            Text {
+                                id: stockQuoteChange
+                                width: parent.width / 2
+                                height: parent.height
+                                text: Functions.renderPrice(price, currency)
+                                color: Theme.highlightColor
+                                font.pixelSize: Theme.fontSizeTiny
+                                font.bold: true
+                                horizontalAlignment: Text.AlignLeft
                             }
 
-                            Row {
-                                id: thirdRow
-                                width: parent.width
-                                height: Theme.fontSizeTiny + Theme.paddingSmall
-
-                                Text {
-                                    id: stockQuoteChange
-                                    width: parent.width / 2
-                                    height: parent.height
-                                    text: Functions.renderPrice(price, currency)
-                                    color: Theme.highlightColor
-                                    font.pixelSize: Theme.fontSizeTiny
-                                    font.bold: true
-                                    horizontalAlignment: Text.AlignLeft
-                                }
-
-                                Text {
-                                    id: changePercentageText
-                                    width: parent.width / 2
-                                    height: parent.height
-                                    text: Functions.renderChange(price, changeRelative, '%')
-                                    color: Functions.determineChangeColor(
-                                               changeRelative)
-                                    font.pixelSize: Theme.fontSizeTiny
-                                    horizontalAlignment: Text.AlignRight
-                                }
+                            Text {
+                                id: changePercentageText
+                                width: parent.width / 2
+                                height: parent.height
+                                text: Functions.renderChange(price, changeRelative, '%')
+                                color: Functions.determineChangeColor(
+                                            changeRelative)
+                                font.pixelSize: Theme.fontSizeTiny
+                                horizontalAlignment: Text.AlignRight
                             }
                         }
                     }

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.2
+import QtQuick 2.6
 import QtQuick.LocalStorage 2.0
 import Sailfish.Silica 1.0
 
@@ -171,22 +171,14 @@ CoverBackground {
         Behavior on opacity { NumberAnimation {} }
         opacity: coverPage.loading ? 0 : 1
         //spacing: Theme.paddingSmall
-        width: parent.width
-        height: parent.height
 
-        anchors {
-            top: parent.top
-            topMargin: Theme.paddingMedium
-            left: parent.left
-            //leftMargin: Theme.paddingMedium
-            right: parent.right
-            rightMargin: Theme.paddingMedium
-            bottom: parent.bottom
-        }
+        anchors.fill: parent
 
         Text {
             id: labelTitle
             width: parent.width
+            topPadding: Theme.paddingLarge
+            bottomPadding: Theme.paddingMedium
             text: coverActionPrevious.enabled ? qsTr("Top") : qsTr("Flop")
             color: Theme.primaryColor
             font.bold: true
@@ -210,23 +202,20 @@ CoverBackground {
 
             delegate: ListItem {
 
-                anchors {
-                    topMargin: Theme.paddingSmall
-                }
-
                 // height: resultLabelTitle.height + resultLabelContent.height + Theme.paddingSmall
                 opacity: index < 4 ? 1.0 - index * 0.2 : 0.0
+                contentHeight: stockQuoteItem.height
 
                 Item {
                     id: stockQuoteItem
-                    width: parent.width
+                    x: Theme.paddingLarge
+                    width: parent.width - 2 * Theme.paddingLarge
                     // height: stockQuoteRow.height + stockQuoteSeparator.height
-                    height: stockQuoteColumn.height + thirdRow.height + Theme.paddingSmall
-                    y: Theme.paddingSmall
+                    height: stockQuoteColumn.height + Theme.paddingSmall
 
                     Row {
                         id: stockQuoteRow
-                        width: parent.width - (2 * Theme.horizontalPageMargin)
+                        width: parent.width
                         //                        spacing: Theme.paddingSmall
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -245,7 +234,7 @@ CoverBackground {
                                 width: parent.width
                                 height: Theme.fontSizeExtraSmall + Theme.paddingSmall
 
-                                Text {
+                                Label {
                                     id: stockQuoteName
                                     width: parent.width // * 8 / 10
                                     height: parent.height
@@ -255,7 +244,7 @@ CoverBackground {
                                     font.pixelSize: Theme.fontSizeExtraSmall
                                     font.bold: true
                                     horizontalAlignment: Text.AlignLeft
-                                    elide: Text.ElideRight
+                                    truncationMode: TruncationMode.Fade
                                 }
                             }
 

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -194,7 +194,6 @@ CoverBackground {
         delegate: ListItem {
 
             // height: resultLabelTitle.height + resultLabelContent.height + Theme.paddingSmall
-            opacity: index < 4 ? 1.0 - index * 0.2 : 0.0
             contentHeight: stockQuoteColumn.height + Theme.paddingSmall
 
             // TODO custom - hier noch pruefen, was an margins noch machbar, sinnvoll ist
@@ -263,6 +262,13 @@ CoverBackground {
         onVisibleChanged: {
             reloadAllStocks()
         }
+    }
+
+    OpacityRampEffect {
+        sourceItem: coverListView
+        direction: OpacityRamp.TopToBottom
+        offset: 0.6
+        slope: 3.75
     }
 
 }

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -165,120 +165,103 @@ CoverBackground {
         }
     }
 
-    Column {
-        id: coverColumn
+    SilicaListView {
+        id: coverListView
+
         visible: !coverPage.loading
         Behavior on opacity { NumberAnimation {} }
         opacity: coverPage.loading ? 0 : 1
-        //spacing: Theme.paddingSmall
 
         anchors.fill: parent
 
-        SilicaListView {
-            id: coverListView
+        model: ListModel {
+            id: coverModel
+        }
 
-            anchors.fill: parent
+        header: Text {
+            id: labelTitle
+            width: parent.width
+            topPadding: Theme.paddingLarge
+            bottomPadding: Theme.paddingMedium
+            text: coverActionPrevious.enabled ? qsTr("Top") : qsTr("Flop")
+            color: Theme.primaryColor
+            font.bold: true
+            font.pixelSize: Theme.fontSizeSmall
+            textFormat: Text.StyledText
+            horizontalAlignment: Text.AlignHCenter
+        }
 
-            model: ListModel {
-                id: coverModel
-            }
+        delegate: ListItem {
 
-            header: Text {
-                id: labelTitle
-                width: parent.width
-                topPadding: Theme.paddingLarge
-                bottomPadding: Theme.paddingMedium
-                text: coverActionPrevious.enabled ? qsTr("Top") : qsTr("Flop")
-                color: Theme.primaryColor
-                font.bold: true
-                font.pixelSize: Theme.fontSizeSmall
-                textFormat: Text.StyledText
-                horizontalAlignment: Text.AlignHCenter
-            }
+            // height: resultLabelTitle.height + resultLabelContent.height + Theme.paddingSmall
+            opacity: index < 4 ? 1.0 - index * 0.2 : 0.0
+            contentHeight: stockQuoteColumn.height + Theme.paddingSmall
 
-            delegate: ListItem {
+            // TODO custom - hier noch pruefen, was an margins noch machbar, sinnvoll ist
+            Column {
+                id: stockQuoteColumn
+                x: Theme.paddingLarge
+                width: parent.width - 2 * Theme.paddingLarge
+                anchors.verticalCenter: parent.verticalCenter
 
-                // height: resultLabelTitle.height + resultLabelContent.height + Theme.paddingSmall
-                opacity: index < 4 ? 1.0 - index * 0.2 : 0.0
-                contentHeight: stockQuoteItem.height
+                Row {
+                    id: firstRow
+                    width: parent.width
+                    height: Theme.fontSizeExtraSmall + Theme.paddingSmall
 
-                Item {
-                    id: stockQuoteItem
-                    x: Theme.paddingLarge
-                    width: parent.width - 2 * Theme.paddingLarge
-                    // height: stockQuoteRow.height + stockQuoteSeparator.height
-                    height: stockQuoteColumn.height + Theme.paddingSmall
+                    Label {
+                        id: stockQuoteName
+                        width: parent.width // * 8 / 10
+                        height: parent.height
+                        text: name
+                        // truncationMode: TruncationMode.Elide // TODO check for very long texts
+                        color: Theme.primaryColor
+                        font.pixelSize: Theme.fontSizeExtraSmall
+                        font.bold: true
+                        horizontalAlignment: Text.AlignLeft
+                        truncationMode: TruncationMode.Fade
+                    }
+                }
 
-                    // TODO custom - hier noch pruefen, was an margins noch machbar, sinnvoll ist
-                    Column {
-                        id: stockQuoteColumn
-                        width: parent.width // - (2 * Theme.horizontalPageMargin)
-                        // x: Theme.horizontalPageMargin
-                        height: firstRow.height //+ changeRow.height
-                        /* + secondRow.height*/ + thirdRow.height
-                        anchors.verticalCenter: parent.verticalCenter
+                Row {
+                    id: thirdRow
+                    width: parent.width
+                    height: Theme.fontSizeTiny + Theme.paddingSmall
 
-                        Row {
-                            id: firstRow
-                            width: parent.width
-                            height: Theme.fontSizeExtraSmall + Theme.paddingSmall
+                    Text {
+                        id: stockQuoteChange
+                        width: parent.width / 2
+                        height: parent.height
+                        text: Functions.renderPrice(price, currency)
+                        color: Theme.highlightColor
+                        font.pixelSize: Theme.fontSizeTiny
+                        font.bold: true
+                        horizontalAlignment: Text.AlignLeft
+                    }
 
-                            Label {
-                                id: stockQuoteName
-                                width: parent.width // * 8 / 10
-                                height: parent.height
-                                text: name
-                                // truncationMode: TruncationMode.Elide // TODO check for very long texts
-                                color: Theme.primaryColor
-                                font.pixelSize: Theme.fontSizeExtraSmall
-                                font.bold: true
-                                horizontalAlignment: Text.AlignLeft
-                                truncationMode: TruncationMode.Fade
-                            }
-                        }
-
-                        Row {
-                            id: thirdRow
-                            width: parent.width
-                            height: Theme.fontSizeTiny + Theme.paddingSmall
-
-                            Text {
-                                id: stockQuoteChange
-                                width: parent.width / 2
-                                height: parent.height
-                                text: Functions.renderPrice(price, currency)
-                                color: Theme.highlightColor
-                                font.pixelSize: Theme.fontSizeTiny
-                                font.bold: true
-                                horizontalAlignment: Text.AlignLeft
-                            }
-
-                            Text {
-                                id: changePercentageText
-                                width: parent.width / 2
-                                height: parent.height
-                                text: Functions.renderChange(price, changeRelative, '%')
-                                color: Functions.determineChangeColor(
-                                            changeRelative)
-                                font.pixelSize: Theme.fontSizeTiny
-                                horizontalAlignment: Text.AlignRight
-                            }
-                        }
+                    Text {
+                        id: changePercentageText
+                        width: parent.width / 2
+                        height: parent.height
+                        text: Functions.renderChange(price, changeRelative, '%')
+                        color: Functions.determineChangeColor(changeRelative)
+                        font.pixelSize: Theme.fontSizeTiny
+                        horizontalAlignment: Text.AlignRight
                     }
                 }
             }
+        }
 
-            Component.onCompleted: {
-                Database.initApplicationTables()
-                var dataBackend = Functions.getDataBackend(watchlistSettings.dataBackend);
-                dataBackend.quoteResultAvailable.connect(quoteResultHandler)
-                dataBackend.requestError.connect(errorResultHandler)
-                reloadAllStocks()
-            }
+        Component.onCompleted: {
+            Database.initApplicationTables()
+            var dataBackend = Functions.getDataBackend(watchlistSettings.dataBackend);
+            dataBackend.quoteResultAvailable.connect(quoteResultHandler)
+            dataBackend.requestError.connect(errorResultHandler)
+            reloadAllStocks()
+        }
 
-            onVisibleChanged: {
-                reloadAllStocks()
-            }
+        onVisibleChanged: {
+            reloadAllStocks()
         }
     }
 

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -174,30 +174,26 @@ CoverBackground {
 
         anchors.fill: parent
 
-        Text {
-            id: labelTitle
-            width: parent.width
-            topPadding: Theme.paddingLarge
-            bottomPadding: Theme.paddingMedium
-            text: coverActionPrevious.enabled ? qsTr("Top") : qsTr("Flop")
-            color: Theme.primaryColor
-            font.bold: true
-            font.pixelSize: Theme.fontSizeSmall
-            textFormat: Text.StyledText
-            horizontalAlignment: Text.AlignHCenter
-        }
-
         SilicaListView {
             id: coverListView
 
-            height: parent.height - labelTitle.height - Theme.paddingSmall
-            width: parent.width
-            anchors.left: parent.left
-            anchors.right: parent.right
-            clip: true
+            anchors.fill: parent
 
             model: ListModel {
                 id: coverModel
+            }
+
+            header: Text {
+                id: labelTitle
+                width: parent.width
+                topPadding: Theme.paddingLarge
+                bottomPadding: Theme.paddingMedium
+                text: coverActionPrevious.enabled ? qsTr("Top") : qsTr("Flop")
+                color: Theme.primaryColor
+                font.bold: true
+                font.pixelSize: Theme.fontSizeSmall
+                textFormat: Text.StyledText
+                horizontalAlignment: Text.AlignHCenter
             }
 
             delegate: ListItem {


### PR DESCRIPTION
### General changes

- Stock name label is using `Fade` truncation mode. There are couple of reasons to do so:
    1. It allows to fit more text into label (about 4 extra symbols)
    1. Silica Reference [states](https://sailfishos.org/develop/docs/silica/qml-sailfishsilica-sailfish-silica-label.html/#truncationMode-prop) that `Fade` is preferred truncation mode in Sailfish

- Cover actions are _mostly_ not overlapping stock items (see screenshots), that required to slightly change items height by overriding default value of [`ListItem.contentHeight`](https://sailfishos.org/develop/docs/silica/qml-sailfishsilica-sailfish-silica-listitem.html/#contentHeight-prop). So now items are arranged a bit more tight.

- Items are faded by `OpacityRampEffect`.

Bump to `QtQuick 2.6` is required to make use of `topPadding`/`bottomPadding` properties of `Text` (whey were introduced with Qt 5.6). If we want to support Sailfish 2.X as well, it might be better to do this with anchors instead. 

### Screenshots

Margins are highlighted to see misalignment. Old layout is on the left side, new one is on the right.

![1-old-vs-new](https://user-images.githubusercontent.com/1594949/84832061-34929b80-b035-11ea-99ab-65815bf5e01d.jpg)

Second screenshot has no any highlighted areas, but it's possible to see that labels are aligned with system app's covers (like Calendar).

![2-watchlist-and-calendar](https://user-images.githubusercontent.com/1594949/84832065-365c5f00-b035-11ea-8a49-20094e4e1434.jpg)

Also I've tested old and new layouts on some devices, and here is result (both with large and small covers):

![3-different-screens](https://user-images.githubusercontent.com/1594949/84832066-36f4f580-b035-11ea-9ce6-c1674b00f3d9.png)

Looks like new layout is also solving issue on tablet :)
